### PR TITLE
 Implement `updateHead` for Locale Changes

### DIFF
--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -41,8 +41,15 @@ export default {
   head: {
     title: function () {
       return {
-        inner: this.$t('nav.about')
+        inner: this.$t('nav.about'),
+        separator: '|',
+        complement: `${this.$t('view.home.name1')} ${this.$t('view.home.name2')}`
       }
+    }
+  },
+  watch: {
+    '$i18n.locale'() {
+      this.$emit('updateHead');
     }
   },
   data () {

--- a/src/views/Collaborators.vue
+++ b/src/views/Collaborators.vue
@@ -15,8 +15,15 @@ export default {
   head: {
     title: function () {
       return {
-        inner: this.$t('view.about.colab')
+        inner: this.$t('view.about.colab'),
+        separator: '|',
+        complement: `${this.$t('view.home.name1')} ${this.$t('view.home.name2')}`
       }
+    }
+  },
+  watch: {
+    '$i18n.locale'() {
+      this.$emit('updateHead');
     }
   },
   components: { AppColab }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -60,6 +60,11 @@ export default {
       }
     }
   },
+  watch: {
+    '$i18n.locale'() {
+      this.$emit('updateHead');
+    }
+  },
   components: {
     FormCurriculo,
     AppActions,

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -12,9 +12,16 @@ export default {
   head: {
     title: function () {
       return {
-        inner: this.$t('view.notfound.text1')
+        inner: this.$t('view.notfound.text1'),
+        separator: '|',
+        complement: `${this.$t('view.home.name1')} ${this.$t('view.home.name2')}`
       }
     }
-  }
+  },
+  watch: {
+    '$i18n.locale'() {
+      this.$emit('updateHead');
+    }
+  },
 }
 </script>


### PR DESCRIPTION
This pull request implements a watcher for the `$i18n.locale` property to ensure the document head updates dynamically when the locale changes. The watcher emits an `updateHead` event, which is handled to update the title and other head elements accordingly.

**Changed Page:**

1. **Home: Update `updateHead`**
   - Added functionality to emit `updateHead` when the locale changes in the Home component.

2. **Collaborators: Update `updateHead` and Title Complement**
   - Updated the collaborators section to respond to the `updateHead` event, ensuring the title is complemented based on the current locale.

3. **About: Update `updateHead` and Title Complement**
   - Implemented similar updates in the About section to reflect locale changes in the document head.
   
4. **NotFound: Update `updateHead` and Title Complement**
   - Implemented similar updates in the NotFound section to reflect locale changes in the document head.

**Changes Made:**

- Implemented a watcher for `$i18n.locale` in relevant components.
- Emitted `updateHead` on locale changes.
- Adjusted methods to update title and other head elements accordingly.

**How to Test:**

1. Change the locale using the i18n settings.
2. Observe that the document head updates correctly (title) based on the new locale.

**Additional Notes:**

- Ensure that the methods handling the `updateHead` event are well-defined to cover all necessary updates in the head.
- Review the changes to confirm the expected behavior across all components.