### PR TITLE
Break media queries

### DIFF
--- a/src/stylus/components/_render.styl
+++ b/src/stylus/components/_render.styl
@@ -14,6 +14,12 @@
     &.viewfixed
       position fixed
       top 0
+  +break(2400px, 'min')
+    &.viewfixed .view
+        max-width 70%
+        position absolute
+        right 1rem
+
 
 .view
   width calc(100% - 20px)

--- a/src/stylus/mixins/_responsive.styl
+++ b/src/stylus/mixins/_responsive.styl
@@ -1,6 +1,12 @@
-break(value)
-  @media (max-width: value)
-    {block}
+break(value, type = 'max')
+  if type == 'max'
+    @media (max-width: value)
+      {block}
+  else if type == 'min'
+    @media (min-width: value)
+      {block}
+  else
+    throw new Error('Invalid type. Use "max" or "min".')
 
 mobile()
   @media (min-width: 640px)


### PR DESCRIPTION
This pull request introduces a responsive `break` mixin to streamline media query creation and adjusts the `.viewfixed .view` styles for enhanced layout control on larger screens.

**Changes Made:**

1. **Responsive `break` Mixin:**
   - A new `break` mixin has been implemented to handle both `max-width` and `min-width` media queries based on the provided `value` and `type`.

   ```stylus
   break(value, type = 'max')
     if type == 'max'
       @media (max-width: value)
         {block}
     else if type == 'min'
       @media (min-width: value)
         {block}
     else
       throw new Error('Invalid type. Use "max" or "min".')
   ```

2. **Adjustment for `.viewfixed .view`:**
   - Added a style rule to adjust the `.viewfixed .view` class for screens wider than 2400px, ensuring a maximum width and proper positioning.

   ```stylus
   +break(2400px, 'min')
     &.viewfixed .view
       max-width 70%
       position absolute
       right 1rem
   ```

**Testing Instructions:**
- Review the implementation of the `break` mixin and test its functionality within the project.
- Verify the styles applied to the `.viewfixed .view` class on screens wider than 2400px to ensure they align with the design specifications.

**Screenshots/Visuals:**
## Before
![Screenshot 2024-10-11 011232](https://github.com/user-attachments/assets/308c5493-0302-4f0e-a47c-3d3c723520d2)

## After
![Screenshot 2024-10-11 011224](https://github.com/user-attachments/assets/cb38b710-e87e-4bca-86cc-96e52460b486)